### PR TITLE
Remove "Intel" in advertised syntax name

### DIFF
--- a/Syntaxes/Assembly x86 Intel.JSON-tmLanguage
+++ b/Syntaxes/Assembly x86 Intel.JSON-tmLanguage
@@ -1,4 +1,4 @@
-{ "name": "Assembly x86 Intel (FASM)",
+{ "name": "Assembly x86 (FASM)",
   "scopeName": "source.asm",
   "fileTypes": ["asm", "ASM", "inc", "INC", "s", "S"],
   "patterns": [

--- a/Syntaxes/Assembly x86 Intel.tmLanguage
+++ b/Syntaxes/Assembly x86 Intel.tmLanguage
@@ -12,7 +12,7 @@
 		<string>S</string>
 	</array>
 	<key>name</key>
-	<string>Assembly x86 Intel (FASM)</string>
+	<string>Assembly x86 (FASM)</string>
 	<key>patterns</key>
 	<array>
 		<dict>


### PR DESCRIPTION
As Shirk/Sublime-FASM-x86 doesn't have Issues, I have to do Pull Request.

"Assembly x86" is from https://sublime.wbond.net/packages/NASM%20x86%20Assembly , I've asked the author to add "(NASM)".

"Assembly x86 (MASM compatible)" is from https://sublime.wbond.net/packages/MasmAssembly

![screenshot from 2013-10-12 13 00 43](https://f.cloud.github.com/assets/1404381/1319584/7a239f14-32fb-11e3-8dac-4e842bdac168.png)
